### PR TITLE
Fix `handler-fn->interceptor` to make the interceptor compatible with Pedestal Interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 0.2.2 - 2025-01-30
+
+### Fixed
+
+- Fix `handler-fn->interceptor` to make the interceptor compatible with Pedestal Interceptor. The `handle-fn` should
+  always return a `context` map.
+
 ## 0.2.1 - 2025-01-30
 
 ### Added

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/scheduler-component "0.2.1"
+(defproject net.clojars.macielti/scheduler-component "0.2.2"
 
   :description "Schedule recurring tasks to be executed at a given time."
 

--- a/src/scheduler_component/core.clj
+++ b/src/scheduler_component/core.clj
@@ -9,7 +9,9 @@
   [handler-fn]
   (interceptor/interceptor
    {:name  ::job-handler-fn-interceptor
-    :enter handler-fn}))
+    :enter (fn [context]
+             (handler-fn context)
+             context)}))
 
 (defmethod ig/init-key ::scheduler
   [_ {:keys [jobs components]}]


### PR DESCRIPTION
### Fixed

- Fix `handler-fn->interceptor` to make the interceptor compatible with Pedestal Interceptor. The `handle-fn` should
  always return a `context` map.